### PR TITLE
Add show-all flag browsing

### DIFF
--- a/backend/data/all_flags/flags.json
+++ b/backend/data/all_flags/flags.json
@@ -630,7 +630,7 @@
    }
   },
   {
-   "name": "2019",
+   "name": "Paralympic flag (2019)",
    "wikipedia_page": "Paralympic_flag",
    "wikipedia_url": "https://en.wikipedia.org/wiki/Paralympic_flag",
    "wikipedia_image_url": "https://upload.wikimedia.org/wikipedia/commons/7/7f/Paralympic_flag_%282019%29.svg",
@@ -655,7 +655,7 @@
    }
   },
   {
-   "name": "2019- Till Date",
+   "name": "Commonwealth Games Federation symbol (2019–present)",
    "wikipedia_page": "Flag_of_the_Commonwealth_of_Nations",
    "wikipedia_url": "https://en.wikipedia.org/wiki/Flag_of_the_Commonwealth_of_Nations",
    "wikipedia_image_url": "https://upload.wikimedia.org/wikipedia/commons/6/6a/Commonwealth_Games_Federation_symbol_%282019-_Till_Date%29.svg",
@@ -23800,7 +23800,7 @@
    }
   },
   {
-   "name": "1930s",
+   "name": "Civil Air Ensign of South Africa (1930s)",
    "wikipedia_page": "1930s",
    "wikipedia_url": "https://en.wikipedia.org/wiki/1930s",
    "wikipedia_image_url": "https://upload.wikimedia.org/wikipedia/commons/8/8e/Civil_Air_Ensign_of_South_Africa_%28obsolete%29.svg",
@@ -23852,7 +23852,7 @@
    }
   },
   {
-   "name": "1981–1994",
+   "name": "South African Defence Force Ensign (1981–1994)",
    "wikipedia_page": "South_African_Defence_Force_Ensign",
    "wikipedia_url": "https://en.wikipedia.org/wiki/South_African_Defence_Force_Ensign",
    "wikipedia_image_url": "https://upload.wikimedia.org/wikipedia/commons/b/bd/Ensign_of_the_South_African_Defence_Force_%281981%E2%80%931994%29.svg",
@@ -24474,7 +24474,7 @@
    }
   },
   {
-   "name": "1995–present",
+   "name": "South African Police Service flag (1995–present)",
    "wikipedia_page": "1995–present",
    "wikipedia_url": "https://en.wikipedia.org/wiki/1995%E2%80%93present",
    "wikipedia_image_url": "https://upload.wikimedia.org/wikipedia/commons/b/b9/Flag_of_the_South_African_Police_Service.svg",

--- a/backend/main.py
+++ b/backend/main.py
@@ -146,5 +146,10 @@ async def flags_info():
     }
 
 
+@app.get("/flags/all", response_model=FlagList)
+async def all_flags():
+    return app.state.flag_searcher.all_flags()
+
+
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/frontend/src/components/Flags.css
+++ b/frontend/src/components/Flags.css
@@ -34,9 +34,11 @@
   margin-bottom: 16px;
 }
 
-.show-all-button {
-  padding: 10px 16px;
+.show-all-label {
   font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  margin-right: 8px;
 }
 
 .filter-options {

--- a/frontend/src/components/Flags.css
+++ b/frontend/src/components/Flags.css
@@ -1,0 +1,61 @@
+.description-form {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.description-input {
+  width: min(320px, 100%);
+  padding: 8px 10px;
+  font-size: 14px;
+}
+
+.description-submit {
+  padding: 8px 14px;
+  font-size: 14px;
+}
+
+.or-divider {
+  margin: 16px 0;
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.show-all-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+}
+
+.show-all-button {
+  padding: 10px 16px;
+  font-size: 15px;
+}
+
+.filter-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+}
+
+.option-button {
+  padding: 6px 12px;
+  font-size: 14px;
+  border: 1px solid #c8c8c8;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.option-button.active {
+  border-color: #2c4dd9;
+  background: #e8edff;
+}

--- a/frontend/src/components/Flags.jsx
+++ b/frontend/src/components/Flags.jsx
@@ -57,6 +57,7 @@ const FlagList = () => {
 
   const toggleSort = async (nextSort) => {
     await ensureAllFlags();
+    setColorFilter(null);
     if (nextSort === "random") {
       setSortOrder("random");
       setRandomSeed((seed) => seed + 1);
@@ -67,7 +68,7 @@ const FlagList = () => {
 
   const toggleColor = async (nextColor) => {
     await ensureAllFlags();
-    setSortOrder((current) => (current === "random" ? null : current));
+    setSortOrder(null);
     setColorFilter((current) => (current === nextColor ? null : nextColor));
   };
 

--- a/frontend/src/components/Flags.jsx
+++ b/frontend/src/components/Flags.jsx
@@ -1,10 +1,33 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
 import api from "../api.js";
 import ImageGrid from "./ImageGrid";
 import SubmitDescriptionForm from "./SubmitDescriptionForm";
+import "./Flags.css";
+
+const COLOR_OPTIONS = [
+  "black",
+  "white",
+  "gray",
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "blue",
+  "light_blue",
+  "purple",
+  "pink",
+];
+
+const COLOR_LABELS = {
+  light_blue: "Light Blue",
+};
 
 const FlagList = () => {
   const [flags, setFlags] = useState([]);
+  const [sortOrder, setSortOrder] = useState(null);
+  const [colorFilter, setColorFilter] = useState(null);
+  const [isLoadingAll, setIsLoadingAll] = useState(false);
+
   const addFlag = async (textQuery) => {
     try {
       const response = await api.post("/", { text_query: textQuery });
@@ -14,20 +37,102 @@ const FlagList = () => {
     }
   };
 
+  const showAllFlags = async () => {
+    setIsLoadingAll(true);
+    try {
+      const response = await api.get("/flags/all");
+      setFlags(response.data.flags);
+    } catch (error) {
+      console.error("Error fetching all flags", error);
+    } finally {
+      setIsLoadingAll(false);
+    }
+  };
+
+  const toggleSort = (nextSort) => {
+    setSortOrder((current) => (current === nextSort ? null : nextSort));
+  };
+
+  const toggleColor = (nextColor) => {
+    setColorFilter((current) => (current === nextColor ? null : nextColor));
+  };
+
+  const displayFlags = useMemo(() => {
+    let nextFlags = [...flags];
+
+    if (colorFilter) {
+      nextFlags = nextFlags.filter(
+        (flag) =>
+          flag.color_coverage && flag.color_coverage[colorFilter] != null,
+      );
+    }
+
+    if (sortOrder) {
+      nextFlags.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+      if (sortOrder === "za") {
+        nextFlags.reverse();
+      }
+    }
+
+    return nextFlags;
+  }, [flags, sortOrder, colorFilter]);
+
+  const handleClear = () => {
+    setFlags([]);
+    setSortOrder(null);
+    setColorFilter(null);
+  };
+
   return (
     <div>
-      <h2>Describe the flag using words</h2>
       <SubmitDescriptionForm addFlag={addFlag} />
+      <div className="or-divider">OR</div>
+      <div className="show-all-controls">
+        <button
+          className="show-all-button"
+          type="button"
+          onClick={showAllFlags}
+          disabled={isLoadingAll}
+        >
+          {isLoadingAll ? "Loading..." : "Show All"}
+        </button>
+        <div className="filter-options">
+          <button
+            className={`option-button ${sortOrder === "az" ? "active" : ""}`}
+            type="button"
+            onClick={() => toggleSort("az")}
+          >
+            A-Z
+          </button>
+          <button
+            className={`option-button ${sortOrder === "za" ? "active" : ""}`}
+            type="button"
+            onClick={() => toggleSort("za")}
+          >
+            Z-A
+          </button>
+          {COLOR_OPTIONS.map((color) => (
+            <button
+              key={color}
+              className={`option-button ${colorFilter === color ? "active" : ""}`}
+              type="button"
+              onClick={() => toggleColor(color)}
+            >
+              {COLOR_LABELS[color] || color.replace("_", " ")}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {flags.length === 0 ? null : (
         <>
           <button
-            onClick={() => setFlags([])}
+            onClick={handleClear}
             style={{ backgroundColor: "#FFCECE", color: "black" }}
           >
             Clear
           </button>
-          <ImageGrid images={flags} title="I bet it's..." />
+          <ImageGrid images={displayFlags} />
         </>
       )}
     </div>

--- a/frontend/src/components/Flags.jsx
+++ b/frontend/src/components/Flags.jsx
@@ -18,16 +18,17 @@ const COLOR_OPTIONS = [
   "pink",
 ];
 
+const COLOR_THRESHOLD = 0.0005;
+
 const COLOR_LABELS = {
-  light_blue: "Light Blue",
+  light_blue: "light blue",
 };
 
 const FlagList = () => {
   const [flags, setFlags] = useState([]);
   const [sortOrder, setSortOrder] = useState(null);
   const [colorFilter, setColorFilter] = useState(null);
-  const [isLoadingAll, setIsLoadingAll] = useState(false);
-
+  const [randomSeed, setRandomSeed] = useState(0);
   const addFlag = async (textQuery) => {
     try {
       const response = await api.post("/", { text_query: textQuery });
@@ -38,22 +39,35 @@ const FlagList = () => {
   };
 
   const showAllFlags = async () => {
-    setIsLoadingAll(true);
     try {
       const response = await api.get("/flags/all");
       setFlags(response.data.flags);
     } catch (error) {
       console.error("Error fetching all flags", error);
-    } finally {
-      setIsLoadingAll(false);
     }
   };
 
-  const toggleSort = (nextSort) => {
+  const ensureAllFlags = async () => {
+    if (flags.length > 0) {
+      return true;
+    }
+    await showAllFlags();
+    return true;
+  };
+
+  const toggleSort = async (nextSort) => {
+    await ensureAllFlags();
+    if (nextSort === "random") {
+      setSortOrder("random");
+      setRandomSeed((seed) => seed + 1);
+      return;
+    }
     setSortOrder((current) => (current === nextSort ? null : nextSort));
   };
 
-  const toggleColor = (nextColor) => {
+  const toggleColor = async (nextColor) => {
+    await ensureAllFlags();
+    setSortOrder((current) => (current === "random" ? null : current));
     setColorFilter((current) => (current === nextColor ? null : nextColor));
   };
 
@@ -61,13 +75,38 @@ const FlagList = () => {
     let nextFlags = [...flags];
 
     if (colorFilter) {
-      nextFlags = nextFlags.filter(
-        (flag) =>
-          flag.color_coverage && flag.color_coverage[colorFilter] != null,
-      );
+      nextFlags = nextFlags.filter((flag) => {
+        const coverage = flag.color_coverage?.[colorFilter];
+        return typeof coverage === "number" && coverage >= COLOR_THRESHOLD;
+      });
+      nextFlags.sort((a, b) => {
+        const aCoverage = a.color_coverage?.[colorFilter] ?? 0;
+        const bCoverage = b.color_coverage?.[colorFilter] ?? 0;
+        return bCoverage - aCoverage;
+      });
+      return nextFlags;
     }
 
+    const createRng = (seed) => {
+      let state = seed || 1;
+      return () => {
+        state |= 0;
+        state = (state + 0x6d2b79f5) | 0;
+        let t = Math.imul(state ^ (state >>> 15), 1 | state);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    };
+
     if (sortOrder) {
+      if (sortOrder === "random") {
+        const rng = createRng(randomSeed);
+        for (let i = nextFlags.length - 1; i > 0; i -= 1) {
+          const j = Math.floor(rng() * (i + 1));
+          [nextFlags[i], nextFlags[j]] = [nextFlags[j], nextFlags[i]];
+        }
+        return nextFlags;
+      }
       nextFlags.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
       if (sortOrder === "za") {
         nextFlags.reverse();
@@ -75,7 +114,7 @@ const FlagList = () => {
     }
 
     return nextFlags;
-  }, [flags, sortOrder, colorFilter]);
+  }, [flags, sortOrder, colorFilter, randomSeed]);
 
   const handleClear = () => {
     setFlags([]);
@@ -88,14 +127,7 @@ const FlagList = () => {
       <SubmitDescriptionForm addFlag={addFlag} />
       <div className="or-divider">OR</div>
       <div className="show-all-controls">
-        <button
-          className="show-all-button"
-          type="button"
-          onClick={showAllFlags}
-          disabled={isLoadingAll}
-        >
-          {isLoadingAll ? "Loading..." : "Show All"}
-        </button>
+        <span className="show-all-label">Show All:</span>
         <div className="filter-options">
           <button
             className={`option-button ${sortOrder === "az" ? "active" : ""}`}
@@ -110,6 +142,13 @@ const FlagList = () => {
             onClick={() => toggleSort("za")}
           >
             Z-A
+          </button>
+          <button
+            className={`option-button ${sortOrder === "random" ? "active" : ""}`}
+            type="button"
+            onClick={() => toggleSort("random")}
+          >
+            Random
           </button>
           {COLOR_OPTIONS.map((color) => (
             <button
@@ -132,7 +171,7 @@ const FlagList = () => {
           >
             Clear
           </button>
-          <ImageGrid images={displayFlags} />
+          <ImageGrid images={displayFlags} coverageColor={colorFilter} />
         </>
       )}
     </div>

--- a/frontend/src/components/ImageGrid.jsx
+++ b/frontend/src/components/ImageGrid.jsx
@@ -19,10 +19,16 @@ const ImageGrid = ({ images, title }) => {
             />
 
             <div className="flag-info">
-              <a href={image.wikipedia_url} target="_blank" rel="noopener noreferrer">
+              <a
+                href={image.wikipedia_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 {image.name}
               </a>{" "}
-              <p>({(image.score * 100).toFixed(1)}%)</p>
+              {typeof image.score === "number" && (
+                <p>({(image.score * 100).toFixed(1)}%)</p>
+              )}
             </div>
           </div>
         ))}

--- a/frontend/src/components/ImageGrid.jsx
+++ b/frontend/src/components/ImageGrid.jsx
@@ -1,37 +1,65 @@
 import React from "react";
 import "./ImageGrid.css";
-const ImageGrid = ({ images, title }) => {
+
+const formatCoverageLabel = (color) => {
+  if (!color) {
+    return "";
+  }
+  if (color === "light_blue") {
+    return "light blue";
+  }
+  return color
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+};
+
+const ImageGrid = ({ images, title, coverageColor }) => {
   console.log({ images });
   return (
     <div>
       {title && <h2 className="grid-title">{title}</h2>}
       <div className="grid-container">
-        {images.map((image, index) => (
-          <div className="grid-item" key={index}>
-            <img
-              src={image.wikipedia_image_url}
-              alt={image.name || "Flag"}
-              loading="lazy"
-              onError={(e) => {
-                e.target.style.display = "none";
-                e.target.parentElement.style.minHeight = "200px";
-              }}
-            />
+        {images.map((image, index) => {
+          const coverageValue =
+            coverageColor &&
+            typeof image.color_coverage?.[coverageColor] === "number"
+              ? image.color_coverage[coverageColor]
+              : null;
+          return (
+            <div className="grid-item" key={index}>
+              <img
+                src={image.wikipedia_image_url}
+                alt={image.name || "Flag"}
+                loading="lazy"
+                onError={(e) => {
+                  e.target.style.display = "none";
+                  e.target.parentElement.style.minHeight = "200px";
+                }}
+              />
 
-            <div className="flag-info">
-              <a
-                href={image.wikipedia_url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {image.name}
-              </a>{" "}
-              {typeof image.score === "number" && (
-                <p>({(image.score * 100).toFixed(1)}%)</p>
-              )}
+              <div className="flag-info">
+                <a
+                  href={image.wikipedia_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {image.name}
+                </a>{" "}
+                {coverageValue !== null ? (
+                  <p>
+                    {formatCoverageLabel(coverageColor)}:{" "}
+                    {(coverageValue * 100).toFixed(1)}%
+                  </p>
+                ) : (
+                  typeof image.score === "number" && (
+                    <p>({(image.score * 100).toFixed(1)}%)</p>
+                  )
+                )}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/SubmitDescriptionForm.jsx
+++ b/frontend/src/components/SubmitDescriptionForm.jsx
@@ -12,14 +12,17 @@ const SubmitDescriptionForm = ({ addFlag }) => {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} className="description-form">
       <input
+        className="description-input"
         type="text"
         value={flagName}
         onChange={(e) => setFlagName(e.target.value)}
-        placeholder="Describe it"
+        placeholder="Describe the flag in words"
       />
-      <button type="submit">Submit</button>
+      <button className="description-submit" type="submit">
+        Submit
+      </button>
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- add a /flags/all endpoint for fetching full flag data
- add show-all UI with sorting and single-color filters
- rename numeric-only flag names to descriptive labels

## Test plan
Some examples:
<img width="1330" height="633" alt="image" src="https://github.com/user-attachments/assets/53ee81e8-82e0-407f-aa83-9dbb1ccdfc5c" />

<img width="1345" height="621" alt="image" src="https://github.com/user-attachments/assets/228724c4-6bd3-4c88-a222-cf7bcca3c0e9" />


<img width="1346" height="630" alt="image" src="https://github.com/user-attachments/assets/c088b727-4674-47e8-94ae-3b5d29b14abb" />

<img width="1304" height="631" alt="image" src="https://github.com/user-attachments/assets/1f8e30a8-43dd-431d-909e-d774be2cc0cc" />

(this last one shows how gray and light blue have gotten mixed in, a future PR will fix that)