### PR TITLE
Keep banner scrolling and link flag images

### DIFF
--- a/frontend/src/components/FlagBanner.css
+++ b/frontend/src/components/FlagBanner.css
@@ -47,8 +47,7 @@
   }
 }
 
-.flag-banner:hover .flag-banner__track,
-.flag-banner:focus-within .flag-banner__track {
+.flag-banner:hover .flag-banner__track {
   animation-play-state: paused;
 }
 

--- a/frontend/src/components/ImageGrid.css
+++ b/frontend/src/components/ImageGrid.css
@@ -32,6 +32,12 @@
   flex-direction: column;
 }
 
+.grid-item__link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
 .grid-item img {
   width: 100%;
   height: 200px;

--- a/frontend/src/components/ImageGrid.jsx
+++ b/frontend/src/components/ImageGrid.jsx
@@ -28,15 +28,23 @@ const ImageGrid = ({ images, title, coverageColor }) => {
               : null;
           return (
             <div className="grid-item" key={index}>
-              <img
-                src={image.wikipedia_image_url}
-                alt={image.name || "Flag"}
-                loading="lazy"
-                onError={(e) => {
-                  e.target.style.display = "none";
-                  e.target.parentElement.style.minHeight = "200px";
-                }}
-              />
+              <a
+                className="grid-item__link"
+                href={image.wikipedia_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={image.name || "Flag"}
+              >
+                <img
+                  src={image.wikipedia_image_url}
+                  alt={image.name || "Flag"}
+                  loading="lazy"
+                  onError={(e) => {
+                    e.target.style.display = "none";
+                    e.target.parentElement.style.minHeight = "200px";
+                  }}
+                />
+              </a>
 
               <div className="flag-info">
                 <a


### PR DESCRIPTION
## Summary
- keep the banner animation running after flag clicks by pausing only on hover
- wrap flag images in links so the image itself opens Wikipedia

## Test plan
- [ ] open the app and verify the banner keeps moving after clicking a flag
- [ ] click a flag image and confirm it opens the correct Wikipedia page