### PR TITLE
Window the flag grid to avoid Wikimedia rate-limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,8 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Playwright
+frontend/test-results/
+frontend/playwright-report/
+frontend/blob-report/

--- a/frontend/e2e/grid-windowing.spec.js
+++ b/frontend/e2e/grid-windowing.spec.js
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+// The grid must render in windows of PAGE_SIZE (60) and reveal more on scroll, rather
+// than mounting every flag at once — mounting all ~2700 hotlinks that many images from
+// Wikimedia simultaneously and gets the browser 429-throttled (blank flags). We mock
+// the API with 300 flags and serve a tiny image for every flag URL, so we can assert
+// both the DOM node count and how many image requests actually fire.
+
+const PAGE_SIZE = 60;
+const TOTAL = 300;
+
+const FLAGS = Array.from({ length: TOTAL }, (_, i) => ({
+  name: `Flag ${i}`,
+  wikipedia_url: "https://example.test/wiki",
+  wikipedia_image_url: `https://img.test/flag-${i}.png`,
+  color_coverage: {},
+  score: 0.5,
+}));
+
+// 1x1 transparent PNG
+const PNG_1x1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQAY3Y2wAAAAAElFTkSuQmCC",
+  "base64",
+);
+
+const gridItemCount = (page) => page.locator(".grid-item").count();
+
+test("Show All windows to 60 items and grows to the full set on scroll", async ({
+  page,
+}) => {
+  let imageRequests = 0;
+
+  await page.route("**/flags/all", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ flags: FLAGS }),
+    }),
+  );
+  await page.route("**/flags/random**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ flags: FLAGS.slice(0, 12) }),
+    }),
+  );
+  await page.route("https://img.test/**", (route) => {
+    imageRequests += 1;
+    route.fulfill({ status: 200, contentType: "image/png", body: PNG_1x1 });
+  });
+
+  await page.goto("/");
+
+  // "Show All" (A-Z sort) loads all 300 flags.
+  await page.getByRole("button", { name: "A-Z" }).click();
+
+  // Only the first window mounts, and we haven't requested more images than that.
+  await expect(page.locator(".grid-item")).toHaveCount(PAGE_SIZE);
+  await expect(page.locator(".grid-sentinel")).toBeVisible();
+  expect(imageRequests).toBeLessThanOrEqual(PAGE_SIZE + 5);
+
+  // Scrolling reveals more, in windows, until the whole set is present.
+  let guard = 0;
+  while ((await gridItemCount(page)) < TOTAL && guard < 20) {
+    const before = await gridItemCount(page);
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect
+      .poll(() => gridItemCount(page), { timeout: 5000 })
+      .toBeGreaterThan(before);
+    guard += 1;
+  }
+
+  // Everything is eventually rendered, the sentinel is gone, and we never requested
+  // more images than flags shown (no mass hotlinking).
+  await expect(page.locator(".grid-item")).toHaveCount(TOTAL);
+  await expect(page.locator(".grid-sentinel")).toHaveCount(0);
+  expect(imageRequests).toBeLessThanOrEqual(TOTAL);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.61.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -954,6 +955,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3560,6 +3577,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "axios": "^1.7.9",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.61.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+// E2E config. The dev server is started automatically; tests mock the backend API
+// (page.route), so no Python backend or network access to Wikimedia is required.
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30000,
+  use: { baseURL: "http://localhost:5173" },
+  webServer: {
+    command: "npm run dev -- --port 5173 --strictPort",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60000,
+  },
+});

--- a/frontend/src/components/ImageGrid.css
+++ b/frontend/src/components/ImageGrid.css
@@ -69,3 +69,8 @@
   color: #888;
   margin-top: 2px;
 }
+
+.grid-sentinel {
+  height: 1px;
+  width: 100%;
+}

--- a/frontend/src/components/ImageGrid.jsx
+++ b/frontend/src/components/ImageGrid.jsx
@@ -1,5 +1,11 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import "./ImageGrid.css";
+
+// Render the grid in windows so we never mount thousands of <img> at once — each
+// image hotlinks Wikimedia, and firing all of them (e.g. "Show All" = ~2700) gets
+// the browser rate-limited (429), which shows as blank flags. We reveal more as the
+// user scrolls to the bottom.
+const PAGE_SIZE = 60;
 
 const formatCoverageLabel = (color) => {
   if (!color) {
@@ -15,12 +21,44 @@ const formatCoverageLabel = (color) => {
 };
 
 const ImageGrid = ({ images, title, coverageColor }) => {
-  console.log({ images });
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const sentinelRef = useRef(null);
+
+  // Reset the window whenever the image set changes (new search / sort / filter).
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [images]);
+
+  // Reveal the next page when the sentinel scrolls into view.
+  useEffect(() => {
+    if (visibleCount >= images.length) {
+      return undefined;
+    }
+    const node = sentinelRef.current;
+    if (!node) {
+      return undefined;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setVisibleCount((count) =>
+            Math.min(count + PAGE_SIZE, images.length),
+          );
+        }
+      },
+      { rootMargin: "400px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [visibleCount, images.length]);
+
+  const visibleImages = images.slice(0, visibleCount);
+
   return (
     <div>
       {title && <h2 className="grid-title">{title}</h2>}
       <div className="grid-container">
-        {images.map((image, index) => {
+        {visibleImages.map((image, index) => {
           const coverageValue =
             coverageColor &&
             typeof image.color_coverage?.[coverageColor] === "number"
@@ -72,6 +110,9 @@ const ImageGrid = ({ images, title, coverageColor }) => {
           );
         })}
       </div>
+      {visibleCount < images.length && (
+        <div ref={sentinelRef} className="grid-sentinel" aria-hidden="true" />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
The grid mounted every result at once (~2,700 for "Show All"), firing thousands of image hotlinks at Wikimedia simultaneously → 429 throttling → blank flags. Now renders in pages of 60 and reveals more via an IntersectionObserver sentinel as you scroll. Bounds concurrent image requests; no effect on small result sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)